### PR TITLE
Improve the benchmark by evaluating multiple models and display the results

### DIFF
--- a/sotopia/cli/benchmark/__init__.py
+++ b/sotopia/cli/benchmark/__init__.py
@@ -1,3 +1,3 @@
-from .benchmark import benchmark, benchmark_display, benchmark_all
+from .benchmark import benchmark
 
-__all__ = ["benchmark", "benchmark_display", "benchmark_all"]
+__all__ = ["benchmark"]

--- a/sotopia/cli/benchmark/__init__.py
+++ b/sotopia/cli/benchmark/__init__.py
@@ -1,3 +1,3 @@
-from .benchmark import benchmark
+from .benchmark import benchmark, benchmark_display, benchmark_all
 
-__all__ = ["benchmark"]
+__all__ = ["benchmark", "benchmark_display", "benchmark_all"]

--- a/sotopia/cli/benchmark/benchmark.py
+++ b/sotopia/cli/benchmark/benchmark.py
@@ -360,7 +360,7 @@ def benchmark_all(
     batch_size: int = typer.Option(10, help="The batch size you want to use."),
     task: str = typer.Option("hard", help="The task id you want to benchmark."),
     print_logs: bool = typer.Option(False, help="Print logs."),
-):
+) -> None:
     for model in model_list:
         benchmark(
             model=model,
@@ -388,7 +388,7 @@ def benchmark_display(
         "gpt-4o", help="The evaluator model you want to use."
     ),
     task: str = typer.Option("hard", help="The task id you want to benchmark."),
-):
+) -> None:
     """
     Usage: sotopia benchmark-display --model-list gpt-4o --model-list together_ai/meta-llama-Llama-3-70b-chat-hf
     Aggregate all the results for the benchmark, as described in https://github.com/sotopia-lab/sotopia-space/blob/main/data_dir/models_vs_gpt35.jsonl
@@ -402,7 +402,7 @@ def benchmark_display(
         if len(episodes) == 0:
             print(f"No episodes found for {model}")
             continue
-        avg_rewards = get_avg_reward(episodes, model)
+        avg_rewards = get_avg_reward(episodes, model)  # type: ignore
         model_rewards_dict[model] = avg_rewards
         print(f"Model: {model}, episodes: {len(episodes)}, Avg Rewards: {avg_rewards}")
 

--- a/sotopia/cli/benchmark/benchmark.py
+++ b/sotopia/cli/benchmark/benchmark.py
@@ -266,7 +266,7 @@ def _set_up_logs(
 def save_to_jsonl(
     model_rewards_dict: Dict[str, Dict[str, float]],
     partner_model: str,
-):
+) -> None:
     simplified_model_name = partner_model.split("/")[-1]
     output_fn = f"./models_vs_{simplified_model_name}.jsonl"
     outputs: List[str] = []

--- a/sotopia/cli/benchmark/benchmark.py
+++ b/sotopia/cli/benchmark/benchmark.py
@@ -395,5 +395,5 @@ def benchmark(
             push_to_db=True,
         )
     benchmark_display(
-        models, partner_model, evaluator_model, task, output_to_jsonl=False
+        models, partner_model, evaluator_model, task, output_to_jsonl=output_to_jsonl
     )


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗
Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 📑 Description
As the title suggests: 
1. Support evaluating multiple models at the same time, simply by `sotopia benchmark-all --model-list gpt-4o --model-list gpt-3.5-turbo`, or just go ahead with the default model names. 
2. Support displaying and saving the results in format in https://github.com/sotopia-lab/sotopia-space/blob/main/data_dir/models_vs_gpt35.jsonl by `sotopia benchmark-display`. (Seems there is no requirement for pandas so I am not sure how to display in a structured way in CLI)

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed
- [ ] Branch name follows `type/descript` (e.g. `feature/add-llm-agents`)
- [ ] Ready for code review

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
