### PR TITLE
Change the input type of the ReachGoalLLMEvaluator

### DIFF
--- a/examples/experiment_eval.py
+++ b/examples/experiment_eval.py
@@ -19,8 +19,10 @@ from sotopia.database import (
     EpisodeLog,
 )
 from sotopia.envs.evaluators import (
+    EvaluationForTwoAgents,
     ReachGoalLLMEvaluator,
     RuleBasedTerminatedEvaluator,
+    SotopiaDimensions,
 )
 from sotopia.envs.parallel import ParallelSotopiaEnv
 from sotopia.generation_utils.generate import LLM_Name
@@ -143,7 +145,10 @@ def _iterate_env_agent_combo_not_in_db(
                     RuleBasedTerminatedEvaluator(max_turn_number=20, max_stale_turn=2),
                 ],
                 terminal_evaluators=[
-                    ReachGoalLLMEvaluator(model_names["env"]),
+                    ReachGoalLLMEvaluator(
+                        model_names["env"],
+                        EvaluationForTwoAgents[SotopiaDimensions],
+                    ),
                 ],
             )
             agent_profiles = [AgentProfile.get(id) for id in agent_ids]

--- a/examples/fix_missing_episodes.py
+++ b/examples/fix_missing_episodes.py
@@ -19,8 +19,10 @@ from sotopia.database.persistent_profile import (
     EnvironmentProfile,
 )
 from sotopia.envs.evaluators import (
+    EvaluationForTwoAgents,
     ReachGoalLLMEvaluator,
     RuleBasedTerminatedEvaluator,
+    SotopiaDimensions,
 )
 from sotopia.envs.parallel import ParallelSotopiaEnv
 from sotopia.generation_utils.generate import LLM_Name
@@ -227,7 +229,10 @@ def yield_env_agent_combo(
                 RuleBasedTerminatedEvaluator(max_turn_number=20, max_stale_turn=2),
             ],
             terminal_evaluators=[
-                ReachGoalLLMEvaluator(model_names["env"]),
+                ReachGoalLLMEvaluator(
+                    model_names["env"],
+                    EvaluationForTwoAgents[SotopiaDimensions],
+                ),
             ],
         )
         agent_profiles = [AgentProfile.get(id) for id in (agent_id1, agent_id2)]

--- a/examples/fix_missing_episodes_with_tag.py
+++ b/examples/fix_missing_episodes_with_tag.py
@@ -35,8 +35,10 @@ from sotopia.database.persistent_profile import (
     EnvironmentProfile,
 )
 from sotopia.envs.evaluators import (
+    EvaluationForTwoAgents,
     ReachGoalLLMEvaluator,
     RuleBasedTerminatedEvaluator,
+    SotopiaDimensions,
 )
 from sotopia.envs.parallel import ParallelSotopiaEnv
 from sotopia.generation_utils.generate import LLM_Name
@@ -325,7 +327,10 @@ def yield_env_agent_combo(
                 RuleBasedTerminatedEvaluator(max_turn_number=20, max_stale_turn=2),
             ],
             terminal_evaluators=[
-                ReachGoalLLMEvaluator(model_names["env"]),
+                ReachGoalLLMEvaluator(
+                    model_names["env"],
+                    EvaluationForTwoAgents[SotopiaDimensions],
+                ),
             ],
         )
         agent_profiles = [AgentProfile.get(id) for id in (agent_id1, agent_id2)]

--- a/sotopia-chat/chat_server.py
+++ b/sotopia-chat/chat_server.py
@@ -27,6 +27,8 @@ from sotopia.envs.evaluators import (
 from sotopia.envs.parallel import ParallelSotopiaEnv
 from sotopia.server import arun_one_episode
 
+from sotopia.envs.evaluators import SotopiaDimensions, EvaluationForTwoAgents
+
 process = subprocess.Popen(
     ["git", "rev-parse", "HEAD"], shell=False, stdout=subprocess.PIPE
 )
@@ -62,7 +64,7 @@ async def _start_server_with_two_session_ids_and_agent_env_combo(
             RuleBasedTerminatedEvaluator(max_turn_number=20, max_stale_turn=2),
         ],
         terminal_evaluators=[
-            ReachGoalLLMEvaluator("gpt-4"),
+            ReachGoalLLMEvaluator("gpt-4", EvaluationForTwoAgents[SotopiaDimensions]),
         ],
     )
     random.shuffle(session_ids)
@@ -95,7 +97,7 @@ async def _start_server_with_one_session_id_and_agent_env_combo(
             RuleBasedTerminatedEvaluator(max_turn_number=20, max_stale_turn=2),
         ],
         terminal_evaluators=[
-            ReachGoalLLMEvaluator("gpt-4"),
+            ReachGoalLLMEvaluator("gpt-4", EvaluationForTwoAgents[SotopiaDimensions]),
         ],
     )
 

--- a/sotopia/cli/benchmark/benchmark.py
+++ b/sotopia/cli/benchmark/benchmark.py
@@ -20,8 +20,10 @@ from sotopia.database import (
 )
 from sotopia.database.serialization import get_rewards_from_episode
 from sotopia.envs.evaluators import (
+    EvaluationForTwoAgents,
     ReachGoalLLMEvaluator,
     RuleBasedTerminatedEvaluator,
+    SotopiaDimensions,
 )
 from sotopia.envs.parallel import ParallelSotopiaEnv
 from sotopia.generation_utils.generate import LLM_Name
@@ -130,7 +132,10 @@ def _list_all_env_agent_combo_not_in_db(
                 RuleBasedTerminatedEvaluator(max_turn_number=20, max_stale_turn=2),
             ],
             terminal_evaluators=[
-                ReachGoalLLMEvaluator(model_names["env"]),
+                ReachGoalLLMEvaluator(
+                    model_names["env"],
+                    EvaluationForTwoAgents[SotopiaDimensions],
+                ),
             ],
         )
         agent_profiles = [AgentProfile.get(id) for id in agent_ids]

--- a/sotopia/server.py
+++ b/sotopia/server.py
@@ -18,8 +18,10 @@ from sotopia.agents.base_agent import BaseAgent
 from sotopia.database import EpisodeLog
 from sotopia.envs import ParallelSotopiaEnv
 from sotopia.envs.evaluators import (
+    EvaluationForTwoAgents,
     ReachGoalLLMEvaluator,
     RuleBasedTerminatedEvaluator,
+    SotopiaDimensions,
     unweighted_aggregate_evaluate,
 )
 from sotopia.generation_utils.generate import LLM_Name, agenerate_script
@@ -268,7 +270,10 @@ async def run_async_server(
                 RuleBasedTerminatedEvaluator(max_turn_number=20, max_stale_turn=2),
             ],
             "terminal_evaluators": [
-                ReachGoalLLMEvaluator(model_dict["env"]),
+                ReachGoalLLMEvaluator(
+                    model_dict["env"],
+                    EvaluationForTwoAgents[SotopiaDimensions],
+                ),
             ],
         }
         agents_model_dict = {
@@ -339,7 +344,10 @@ async def arun_one_script(
     env_message = [("Environment", script_background)]
     agent_messages = env_message + agent_messages
 
-    evaluator = ReachGoalLLMEvaluator(model_name="gpt-4")
+    evaluator = ReachGoalLLMEvaluator(
+        model_name="gpt-4",
+        response_format_class=EvaluationForTwoAgents[SotopiaDimensions],
+    )
     response = unweighted_aggregate_evaluate(
         list(
             itertools.chain(
@@ -407,7 +415,10 @@ async def aevaluate_one_episode(
     history = episode.rewards_prompt.replace("Prompt after formatting:", "").split(
         ",\nBased on previous interactions"
     )[0]
-    evaluator = ReachGoalLLMEvaluator(model_name=model)
+    evaluator = ReachGoalLLMEvaluator(
+        model_name=model,
+        response_format_class=EvaluationForTwoAgents[SotopiaDimensions],
+    )
     response = unweighted_aggregate_evaluate(
         list(
             itertools.chain(

--- a/sotopia/server.py
+++ b/sotopia/server.py
@@ -407,7 +407,7 @@ async def aevaluate_one_episode(
     history = episode.rewards_prompt.replace("Prompt after formatting:", "").split(
         ",\nBased on previous interactions"
     )[0]
-    evaluator = ReachGoalLLMEvaluator(model_name=model, response_format="basic")
+    evaluator = ReachGoalLLMEvaluator(model_name=model)
     response = unweighted_aggregate_evaluate(
         list(
             itertools.chain(

--- a/tests/envs/test_evaluators.py
+++ b/tests/envs/test_evaluators.py
@@ -6,6 +6,7 @@ from sotopia.envs.evaluators import (
     ReachGoalLLMEvaluator,
     RuleBasedTerminatedEvaluator,
     unweighted_aggregate_evaluate,
+    EnvResponseGoalOnly,
 )
 from sotopia.messages import AgentAction, Observation, ScriptBackground, SimpleMessage
 
@@ -177,7 +178,9 @@ async def test_reach_goal_llm_evaluator_async() -> None:
 
 @pytest.mark.asyncio
 async def test_reach_goal_llm_evaluator_goalonly_async() -> None:
-    evaluator = ReachGoalLLMEvaluator("gpt-4", response_format="goal_only")
+    evaluator = ReachGoalLLMEvaluator(
+        "gpt-4", response_format_class=EnvResponseGoalOnly
+    )
     background = ScriptBackground(
         scenario="Conversation between two friends at a trivia night",
         p1_name="Samuel Anderson",

--- a/tests/envs/test_evaluators.py
+++ b/tests/envs/test_evaluators.py
@@ -3,10 +3,11 @@ import asyncio
 import pytest
 
 from sotopia.envs.evaluators import (
+    SotopiaDimensions,
+    EvaluationForTwoAgents,
     ReachGoalLLMEvaluator,
     RuleBasedTerminatedEvaluator,
     unweighted_aggregate_evaluate,
-    EnvResponseGoalOnly,
 )
 from sotopia.messages import AgentAction, Observation, ScriptBackground, SimpleMessage
 
@@ -127,7 +128,9 @@ async def test_rule_based_teminated_evaluator_async() -> None:
 
 @pytest.mark.asyncio
 async def test_reach_goal_llm_evaluator_async() -> None:
-    evaluator = ReachGoalLLMEvaluator("gpt-4")
+    evaluator = ReachGoalLLMEvaluator(
+        "gpt-4", response_format_class=EvaluationForTwoAgents[SotopiaDimensions]
+    )
     response1, response2 = await asyncio.gather(
         evaluator.__acall__(
             1,
@@ -177,9 +180,9 @@ async def test_reach_goal_llm_evaluator_async() -> None:
 
 
 @pytest.mark.asyncio
-async def test_reach_goal_llm_evaluator_goalonly_async() -> None:
+async def test_reach_goal_llm_evaluator_goal_only_async() -> None:
     evaluator = ReachGoalLLMEvaluator(
-        "gpt-4", response_format_class=EnvResponseGoalOnly
+        "gpt-4", response_format_class=EvaluationForTwoAgents[SotopiaDimensions]
     )
     background = ScriptBackground(
         scenario="Conversation between two friends at a trivia night",


### PR DESCRIPTION
Following the discussion in https://github.com/sotopia-lab/sotopia/pull/123#discussion_r1659212670.
I change the input type annotation from `str` to `EnvResponseType` (i.e. `EnvResponseType = Union[EnvResponse, EnvResponsePlus, EnvResponseGoalOnly]`).
Also modify the naming a little bit.
