### PR TITLE
upgrade default model to handle bad-foratted outputs to gpt-4o-mini

### DIFF
--- a/sotopia/generation_utils/generate.py
+++ b/sotopia/generation_utils/generate.py
@@ -391,7 +391,7 @@ def format_bad_output_for_script(
     ill_formed_output: str,
     format_instructions: str,
     agents: list[str],
-    model_name: str = "gpt-3.5-turbo",
+    model_name: str = "gpt-4o-mini",
 ) -> BaseMessage:
     template = """
     Given the string that can not be parsed by a parser, reformat it to a string that can be parsed by the parser which uses the following format instructions. Do not add or delete any information.
@@ -425,7 +425,7 @@ def format_bad_output_for_script(
 def format_bad_output(
     ill_formed_output: BaseMessage,
     format_instructions: str,
-    model_name: str = "gpt-3.5-turbo",
+    model_name: str = "gpt-4o-mini",
 ) -> BaseMessage:
     template = """
     Given the string that can not be parsed by json parser, reformat it to a string that can be parsed by json parser.


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗
Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
<!-- Issue # here -->

## 📑 Description
<!-- Add a brief description of the pr -->
Upgrade the default model to handle bad-formatted outputs to GPT-4o-mini as GPT-3.5-turbo is deprecated. See deprecation notice: https://platform.openai.com/docs/deprecations. If we do not apply this change, we will not be able to run Sotopia. 

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed
- [x] Branch name follows `type/descript` (e.g. `feature/add-llm-agents`)
- [x] Ready for code review

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
