### PR TITLE
Add `bad_output_process_model` option and `use_fixed_model_version` option for all generation methods, to avoid future OpenAI API changes break Sotopia running.

### DIFF
--- a/docs/pages/concepts/generation.md
+++ b/docs/pages/concepts/generation.md
@@ -12,6 +12,8 @@ async def agenerate(
     output_parser: BaseOutputParser[OutputType],
     temperature: float = 0.7,
     structured_output: bool = False,
+    bad_output_process_model: str = DEFAULT_BAD_OUTPUT_PROCESS_MODEL,
+    use_fixed_model_version: bool = True
 ) -> OutputType:
     input_variables = re.findall(r"(?<!{){([^{}]+)}(?!})", template)
 ```
@@ -22,6 +24,12 @@ The `agenerate` function is versatile by taking the output_parser as an argument
   Currently, the structured output is only supported for the models below:
     * `gpt-4o-mini-2024-07-18` and later
     * `gpt-4o-2024-08-06` and later
+
+The `bad_output_process_model` is used to process the bad output. `DEFAULT_BAD_OUTPUT_PROCESS_MODEL` is set to be `gpt-4o-mini` (At the publication time of Sotopia, we used `gpt-3.5-turbo-0613`. However this model has been taken off the shelf by OpenAI.).
+
+The `use_fixed_model_version` is used to determine whether to use the fixed model version. If set to `True`, the model version will be fixed to the version that was used in Sotopia paper. If set to `False`, the model version will be the latest version available.
+
+Warning: As some fixed model versions might not be available in the OpenAI API, setting `use_fixed_model_version = True` might result in an error.
 
 </Callout>
 
@@ -37,6 +45,8 @@ async def agenerate_env_profile(
     inspiration_prompt: str = "asking my boyfriend to stop being friends with his ex",
     examples: str = "",
     temperature: float = 0.7,
+    bad_output_process_model: str = DEFAULT_BAD_OUTPUT_PROCESS_MODEL,
+    use_fixed_model_version: bool = True
 ) -> tuple[EnvironmentProfile, str]:
     """
     Using langchain to generate the background
@@ -56,6 +66,8 @@ async def agenerate_env_profile(
         ),
         output_parser=PydanticOutputParser(pydantic_object=EnvironmentProfile),
         temperature=temperature,
+        bad_output_process_model=bad_output_process_model,
+        use_fixed_model_version=use_fixed_model_version
     )
 ```
 ### Other generation functions
@@ -66,6 +78,8 @@ Similarly, there are other utility functions that builds upon the `agenerate` fu
 async def agenerate_relationship_profile(
     model_name: str,
     agents_profiles: list[str],
+    bad_output_process_model: str = DEFAULT_BAD_OUTPUT_PROCESS_MODEL,
+    use_fixed_model_version: bool = True
 ) -> tuple[RelationshipProfile, str]
 ```
 
@@ -78,5 +92,7 @@ async def agenerate_script(
     agent_name: str = "",
     history: str = "",
     single_step: bool = False,
+    bad_output_process_model: str = DEFAULT_BAD_OUTPUT_PROCESS_MODEL,
+    use_fixed_model_version: bool = True
 ) -> tuple[ScriptInteractionReturnType, str]
 ```

--- a/sotopia/generation_utils/generate.py
+++ b/sotopia/generation_utils/generate.py
@@ -306,7 +306,7 @@ def obtain_chain(
     input_variables: list[str],
     temperature: float = 0.7,
     max_retries: int = 6,
-    use_fixed_model_version: bool = True
+    use_fixed_model_version: bool = True,
 ) -> RunnableSerializable[dict[Any, Any], BaseMessage]:
     """
     Using langchain to sample profiles for participants
@@ -396,7 +396,7 @@ def format_bad_output_for_script(
     format_instructions: str,
     agents: list[str],
     model_name: str = DEFAULT_BAD_OUTPUT_PROCESS_MODEL,
-    use_fixed_model_version: bool = True
+    use_fixed_model_version: bool = True,
 ) -> BaseMessage:
     template = """
     Given the string that can not be parsed by a parser, reformat it to a string that can be parsed by the parser which uses the following format instructions. Do not add or delete any information.
@@ -415,7 +415,7 @@ def format_bad_output_for_script(
         model_name=model_name,
         template=template,
         input_variables=re.findall(r"{(.*?)}", template),
-        use_fixed_model_version=use_fixed_model_version
+        use_fixed_model_version=use_fixed_model_version,
     )
     input_values = {
         "ill_formed_output": ill_formed_output,
@@ -432,7 +432,7 @@ def format_bad_output(
     ill_formed_output: BaseMessage,
     format_instructions: str,
     model_name: str = DEFAULT_BAD_OUTPUT_PROCESS_MODEL,
-    use_fixed_model_version: bool = True
+    use_fixed_model_version: bool = True,
 ) -> BaseMessage:
     template = """
     Given the string that can not be parsed by json parser, reformat it to a string that can be parsed by json parser.
@@ -446,7 +446,7 @@ def format_bad_output(
         model_name=model_name,
         template=template,
         input_variables=re.findall(r"{(.*?)}", template),
-        use_fixed_model_version=use_fixed_model_version
+        use_fixed_model_version=use_fixed_model_version,
     )
     input_values = {
         "ill_formed_output": ill_formed_output.content,
@@ -467,7 +467,7 @@ async def agenerate(
     temperature: float = 0.7,
     structured_output: bool = False,
     bad_output_process_model: str = DEFAULT_BAD_OUTPUT_PROCESS_MODEL,
-    use_fixed_model_version: bool = True
+    use_fixed_model_version: bool = True,
 ) -> OutputType:
     input_variables = re.findall(
         r"(?<!{){([^{}]+)}(?!})", template
@@ -483,7 +483,7 @@ async def agenerate(
         template=template,
         input_variables=input_variables,
         temperature=temperature,
-        use_fixed_model_version=use_fixed_model_version
+        use_fixed_model_version=use_fixed_model_version,
     )
 
     if "format_instructions" not in input_values:
@@ -527,9 +527,10 @@ async def agenerate(
             extra={"markup": True},
         )
         reformat_parsed_result = format_bad_output(
-            result, format_instructions=output_parser.get_format_instructions(),
+            result,
+            format_instructions=output_parser.get_format_instructions(),
             model_name=bad_output_process_model,
-            use_fixed_model_version=use_fixed_model_version
+            use_fixed_model_version=use_fixed_model_version,
         )
         parsed_result = output_parser.invoke(reformat_parsed_result)
     log.info(f"Generated result: {parsed_result}")
@@ -544,7 +545,7 @@ async def agenerate_env_profile(
     examples: str = "",
     temperature: float = 0.7,
     bad_output_process_model: str = DEFAULT_BAD_OUTPUT_PROCESS_MODEL,
-    use_fixed_model_version: bool = True
+    use_fixed_model_version: bool = True,
 ) -> tuple[EnvironmentProfile, str]:
     """
     Using langchain to generate the background
@@ -565,7 +566,7 @@ async def agenerate_env_profile(
         output_parser=PydanticOutputParser(pydantic_object=EnvironmentProfile),
         temperature=temperature,
         bad_output_process_model=bad_output_process_model,
-        use_fixed_model_version=use_fixed_model_version
+        use_fixed_model_version=use_fixed_model_version,
     )
 
 
@@ -574,7 +575,7 @@ async def agenerate_relationship_profile(
     model_name: str,
     agents_profiles: list[str],
     bad_output_process_model: str = DEFAULT_BAD_OUTPUT_PROCESS_MODEL,
-    use_fixed_model_version: bool = True
+    use_fixed_model_version: bool = True,
 ) -> tuple[RelationshipProfile, str]:
     """
     Using langchain to generate the background
@@ -592,7 +593,7 @@ async def agenerate_relationship_profile(
         ),
         output_parser=PydanticOutputParser(pydantic_object=RelationshipProfile),
         bad_output_process_model=bad_output_process_model,
-        use_fixed_model_version=use_fixed_model_version
+        use_fixed_model_version=use_fixed_model_version,
     )
 
 
@@ -608,7 +609,7 @@ async def agenerate_action(
     temperature: float = 0.7,
     script_like: bool = False,
     bad_output_process_model: str = DEFAULT_BAD_OUTPUT_PROCESS_MODEL,
-    use_fixed_model_version: bool = True
+    use_fixed_model_version: bool = True,
 ) -> AgentAction:
     """
     Using langchain to generate an example episode
@@ -659,7 +660,7 @@ async def agenerate_action(
             output_parser=PydanticOutputParser(pydantic_object=AgentAction),
             temperature=temperature,
             bad_output_process_model=bad_output_process_model,
-            use_fixed_model_version=use_fixed_model_version
+            use_fixed_model_version=use_fixed_model_version,
         )
     except Exception:
         return AgentAction(action_type="none", argument="")
@@ -676,7 +677,7 @@ async def agenerate_script(
     history: str = "",
     single_step: bool = False,
     bad_output_process_model: str = DEFAULT_BAD_OUTPUT_PROCESS_MODEL,
-    use_fixed_model_version: bool = True
+    use_fixed_model_version: bool = True,
 ) -> tuple[ScriptInteractionReturnType, str]:
     """
     Using langchain to generate an the script interactions between two agent
@@ -711,7 +712,7 @@ async def agenerate_script(
                 ),
                 temperature=temperature,
                 bad_output_process_model=bad_output_process_model,
-                use_fixed_model_version=use_fixed_model_version
+                use_fixed_model_version=use_fixed_model_version,
             )
 
         else:
@@ -735,7 +736,7 @@ async def agenerate_script(
                 ),
                 temperature=temperature,
                 bad_output_process_model=bad_output_process_model,
-                use_fixed_model_version=use_fixed_model_version
+                use_fixed_model_version=use_fixed_model_version,
             )
     except Exception as e:
         # TODO raise(e) # Maybe we do not want to return anything?
@@ -764,7 +765,12 @@ def process_history(
 
 
 @beartype
-async def agenerate_init_profile(model_name: str, basic_info: dict[str, str], bad_output_process_model: str = DEFAULT_BAD_OUTPUT_PROCESS_MODEL, use_fixed_model_version: bool = True) -> str:
+async def agenerate_init_profile(
+    model_name: str,
+    basic_info: dict[str, str],
+    bad_output_process_model: str = DEFAULT_BAD_OUTPUT_PROCESS_MODEL,
+    use_fixed_model_version: bool = True,
+) -> str:
     """
     Using langchain to generate the background
     """
@@ -799,12 +805,18 @@ async def agenerate_init_profile(model_name: str, basic_info: dict[str, str], ba
         ),
         output_parser=StrOutputParser(),
         bad_output_process_model=bad_output_process_model,
-        use_fixed_model_version=use_fixed_model_version
+        use_fixed_model_version=use_fixed_model_version,
     )
 
 
 @beartype
-async def convert_narratives(model_name: str, narrative: str, text: str, bad_output_process_model: str = DEFAULT_BAD_OUTPUT_PROCESS_MODEL, use_fixed_model_version: bool = True) -> str:
+async def convert_narratives(
+    model_name: str,
+    narrative: str,
+    text: str,
+    bad_output_process_model: str = DEFAULT_BAD_OUTPUT_PROCESS_MODEL,
+    use_fixed_model_version: bool = True,
+) -> str:
     if narrative == "first":
         return await agenerate(
             model_name=model_name,
@@ -814,7 +826,7 @@ async def convert_narratives(model_name: str, narrative: str, text: str, bad_out
             input_values=dict(text=text),
             output_parser=StrOutputParser(),
             bad_output_process_model=bad_output_process_model,
-            use_fixed_model_version=use_fixed_model_version
+            use_fixed_model_version=use_fixed_model_version,
         )
     elif narrative == "second":
         return await agenerate(
@@ -825,14 +837,19 @@ async def convert_narratives(model_name: str, narrative: str, text: str, bad_out
             input_values=dict(text=text),
             output_parser=StrOutputParser(),
             bad_output_process_model=bad_output_process_model,
-            use_fixed_model_version=use_fixed_model_version
+            use_fixed_model_version=use_fixed_model_version,
         )
     else:
         raise ValueError(f"Narrative {narrative} is not supported.")
 
 
 @beartype
-async def agenerate_goal(model_name: str, background: str, bad_output_process_model: str = DEFAULT_BAD_OUTPUT_PROCESS_MODEL, use_fixed_model_version: bool = True) -> str:
+async def agenerate_goal(
+    model_name: str,
+    background: str,
+    bad_output_process_model: str = DEFAULT_BAD_OUTPUT_PROCESS_MODEL,
+    use_fixed_model_version: bool = True,
+) -> str:
     """
     Using langchain to generate the background
     """
@@ -844,5 +861,5 @@ async def agenerate_goal(model_name: str, background: str, bad_output_process_mo
         input_values=dict(background=background),
         output_parser=StrOutputParser(),
         bad_output_process_model=bad_output_process_model,
-        use_fixed_model_version=use_fixed_model_version
+        use_fixed_model_version=use_fixed_model_version,
     )

--- a/sotopia/generation_utils/generate.py
+++ b/sotopia/generation_utils/generate.py
@@ -55,6 +55,8 @@ LLM_Name = Literal[
     "redis",
     "groq/llama3-70b-8192",
 ]
+# subject to future OpenAI changes
+DEFAULT_BAD_OUTPUT_PROCESS_MODEL = "gpt-4o-mini"
 
 OutputType = TypeVar("OutputType", bound=object)
 client = OpenAI()
@@ -304,6 +306,7 @@ def obtain_chain(
     input_variables: list[str],
     temperature: float = 0.7,
     max_retries: int = 6,
+    use_fixed_model_version: bool = True
 ) -> RunnableSerializable[dict[Any, Any], BaseMessage]:
     """
     Using langchain to sample profiles for participants
@@ -315,7 +318,8 @@ def obtain_chain(
         )
     )
     chat_prompt_template = ChatPromptTemplate.from_messages([human_message_prompt])
-    model_name = _return_fixed_model_version(model_name)
+    if use_fixed_model_version:
+        model_name = _return_fixed_model_version(model_name)
     if model_name.startswith("together_ai"):
         model_name = "/".join(model_name.split("/")[1:])
         chat_openai = ChatOpenAI(
@@ -391,7 +395,8 @@ def format_bad_output_for_script(
     ill_formed_output: str,
     format_instructions: str,
     agents: list[str],
-    model_name: str = "gpt-4o-mini",
+    model_name: str = DEFAULT_BAD_OUTPUT_PROCESS_MODEL,
+    use_fixed_model_version: bool = True
 ) -> BaseMessage:
     template = """
     Given the string that can not be parsed by a parser, reformat it to a string that can be parsed by the parser which uses the following format instructions. Do not add or delete any information.
@@ -410,6 +415,7 @@ def format_bad_output_for_script(
         model_name=model_name,
         template=template,
         input_variables=re.findall(r"{(.*?)}", template),
+        use_fixed_model_version=use_fixed_model_version
     )
     input_values = {
         "ill_formed_output": ill_formed_output,
@@ -425,7 +431,8 @@ def format_bad_output_for_script(
 def format_bad_output(
     ill_formed_output: BaseMessage,
     format_instructions: str,
-    model_name: str = "gpt-4o-mini",
+    model_name: str = DEFAULT_BAD_OUTPUT_PROCESS_MODEL,
+    use_fixed_model_version: bool = True
 ) -> BaseMessage:
     template = """
     Given the string that can not be parsed by json parser, reformat it to a string that can be parsed by json parser.
@@ -439,6 +446,7 @@ def format_bad_output(
         model_name=model_name,
         template=template,
         input_variables=re.findall(r"{(.*?)}", template),
+        use_fixed_model_version=use_fixed_model_version
     )
     input_values = {
         "ill_formed_output": ill_formed_output.content,
@@ -458,6 +466,8 @@ async def agenerate(
     output_parser: BaseOutputParser[OutputType],
     temperature: float = 0.7,
     structured_output: bool = False,
+    bad_output_process_model: str = DEFAULT_BAD_OUTPUT_PROCESS_MODEL,
+    use_fixed_model_version: bool = True
 ) -> OutputType:
     input_variables = re.findall(
         r"(?<!{){([^{}]+)}(?!})", template
@@ -473,6 +483,7 @@ async def agenerate(
         template=template,
         input_variables=input_variables,
         temperature=temperature,
+        use_fixed_model_version=use_fixed_model_version
     )
 
     if "format_instructions" not in input_values:
@@ -516,7 +527,9 @@ async def agenerate(
             extra={"markup": True},
         )
         reformat_parsed_result = format_bad_output(
-            result, format_instructions=output_parser.get_format_instructions()
+            result, format_instructions=output_parser.get_format_instructions(),
+            model_name=bad_output_process_model,
+            use_fixed_model_version=use_fixed_model_version
         )
         parsed_result = output_parser.invoke(reformat_parsed_result)
     log.info(f"Generated result: {parsed_result}")
@@ -530,6 +543,8 @@ async def agenerate_env_profile(
     inspiration_prompt: str = "asking my boyfriend to stop being friends with his ex",
     examples: str = "",
     temperature: float = 0.7,
+    bad_output_process_model: str = DEFAULT_BAD_OUTPUT_PROCESS_MODEL,
+    use_fixed_model_version: bool = True
 ) -> tuple[EnvironmentProfile, str]:
     """
     Using langchain to generate the background
@@ -549,6 +564,8 @@ async def agenerate_env_profile(
         ),
         output_parser=PydanticOutputParser(pydantic_object=EnvironmentProfile),
         temperature=temperature,
+        bad_output_process_model=bad_output_process_model,
+        use_fixed_model_version=use_fixed_model_version
     )
 
 
@@ -556,6 +573,8 @@ async def agenerate_env_profile(
 async def agenerate_relationship_profile(
     model_name: str,
     agents_profiles: list[str],
+    bad_output_process_model: str = DEFAULT_BAD_OUTPUT_PROCESS_MODEL,
+    use_fixed_model_version: bool = True
 ) -> tuple[RelationshipProfile, str]:
     """
     Using langchain to generate the background
@@ -572,6 +591,8 @@ async def agenerate_relationship_profile(
             agent_profile=agent_profile,
         ),
         output_parser=PydanticOutputParser(pydantic_object=RelationshipProfile),
+        bad_output_process_model=bad_output_process_model,
+        use_fixed_model_version=use_fixed_model_version
     )
 
 
@@ -586,6 +607,8 @@ async def agenerate_action(
     goal: str,
     temperature: float = 0.7,
     script_like: bool = False,
+    bad_output_process_model: str = DEFAULT_BAD_OUTPUT_PROCESS_MODEL,
+    use_fixed_model_version: bool = True
 ) -> AgentAction:
     """
     Using langchain to generate an example episode
@@ -635,6 +658,8 @@ async def agenerate_action(
             ),
             output_parser=PydanticOutputParser(pydantic_object=AgentAction),
             temperature=temperature,
+            bad_output_process_model=bad_output_process_model,
+            use_fixed_model_version=use_fixed_model_version
         )
     except Exception:
         return AgentAction(action_type="none", argument="")
@@ -650,6 +675,8 @@ async def agenerate_script(
     agent_name: str = "",
     history: str = "",
     single_step: bool = False,
+    bad_output_process_model: str = DEFAULT_BAD_OUTPUT_PROCESS_MODEL,
+    use_fixed_model_version: bool = True
 ) -> tuple[ScriptInteractionReturnType, str]:
     """
     Using langchain to generate an the script interactions between two agent
@@ -683,6 +710,8 @@ async def agenerate_script(
                     single_turn=True,
                 ),
                 temperature=temperature,
+                bad_output_process_model=bad_output_process_model,
+                use_fixed_model_version=use_fixed_model_version
             )
 
         else:
@@ -705,6 +734,8 @@ async def agenerate_script(
                     single_turn=False,
                 ),
                 temperature=temperature,
+                bad_output_process_model=bad_output_process_model,
+                use_fixed_model_version=use_fixed_model_version
             )
     except Exception as e:
         # TODO raise(e) # Maybe we do not want to return anything?
@@ -733,7 +764,7 @@ def process_history(
 
 
 @beartype
-async def agenerate_init_profile(model_name: str, basic_info: dict[str, str]) -> str:
+async def agenerate_init_profile(model_name: str, basic_info: dict[str, str], bad_output_process_model: str = DEFAULT_BAD_OUTPUT_PROCESS_MODEL, use_fixed_model_version: bool = True) -> str:
     """
     Using langchain to generate the background
     """
@@ -767,11 +798,13 @@ async def agenerate_init_profile(model_name: str, basic_info: dict[str, str]) ->
             secret=basic_info["secret"],
         ),
         output_parser=StrOutputParser(),
+        bad_output_process_model=bad_output_process_model,
+        use_fixed_model_version=use_fixed_model_version
     )
 
 
 @beartype
-async def convert_narratives(model_name: str, narrative: str, text: str) -> str:
+async def convert_narratives(model_name: str, narrative: str, text: str, bad_output_process_model: str = DEFAULT_BAD_OUTPUT_PROCESS_MODEL, use_fixed_model_version: bool = True) -> str:
     if narrative == "first":
         return await agenerate(
             model_name=model_name,
@@ -780,6 +813,8 @@ async def convert_narratives(model_name: str, narrative: str, text: str) -> str:
             {text}""",
             input_values=dict(text=text),
             output_parser=StrOutputParser(),
+            bad_output_process_model=bad_output_process_model,
+            use_fixed_model_version=use_fixed_model_version
         )
     elif narrative == "second":
         return await agenerate(
@@ -789,13 +824,15 @@ async def convert_narratives(model_name: str, narrative: str, text: str) -> str:
             {text}""",
             input_values=dict(text=text),
             output_parser=StrOutputParser(),
+            bad_output_process_model=bad_output_process_model,
+            use_fixed_model_version=use_fixed_model_version
         )
     else:
         raise ValueError(f"Narrative {narrative} is not supported.")
 
 
 @beartype
-async def agenerate_goal(model_name: str, background: str) -> str:
+async def agenerate_goal(model_name: str, background: str, bad_output_process_model: str = DEFAULT_BAD_OUTPUT_PROCESS_MODEL, use_fixed_model_version: bool = True) -> str:
     """
     Using langchain to generate the background
     """
@@ -806,4 +843,6 @@ async def agenerate_goal(model_name: str, background: str) -> str:
             """,
         input_values=dict(background=background),
         output_parser=StrOutputParser(),
+        bad_output_process_model=bad_output_process_model,
+        use_fixed_model_version=use_fixed_model_version
     )


### PR DESCRIPTION

<!--
Thanks for creating this pull request 🤗
Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 📑 Description
<!-- Add a brief description of the pr -->
Two major updates: 
1) add "bad_output_process_model" option to all `agenerate_xxx()` methods so users can decide which model to use for handling bad outputs. By default, this is set to be `gpt-4o-mini`. 

2) add `use_fixed_model_version` option for all generation methods, as some fixed model version may no longer available in the future. Users should have the right to bypass the fixed model version mapping instead of getting stuck in an error. 

Document (`generation.md`) has been updated for these two major changes correspondingly.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [ ] All the tests have passed
- [x] Branch name follows `type/descript` (e.g. `feature/add-llm-agents`)
- [x] Ready for code review

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
