### PR TITLE
fix: `pk` field type conflict with `JsonModel.pk`

### DIFF
--- a/sotopia/database/persistent_profile.py
+++ b/sotopia/database/persistent_profile.py
@@ -1,12 +1,13 @@
-from enum import IntEnum
 import sys
+from enum import IntEnum
+from typing import Any
 
 if sys.version_info >= (3, 11):
     from typing import Self
 else:
     from typing_extensions import Self
 
-from pydantic import model_validator, BaseModel
+from pydantic import BaseModel, model_validator
 from redis_om import JsonModel
 from redis_om.model.model import Field
 
@@ -21,7 +22,7 @@ class RelationshipType(IntEnum):
 
 
 class BaseAgentProfile(BaseModel):
-    pk: str = Field(default_factory=lambda: "")
+    pk: str | None = Field(default_factory=lambda: "")
     first_name: str = Field(index=True)
     last_name: str = Field(index=True)
     age: int = Field(index=True, default_factory=lambda: 0)
@@ -45,11 +46,14 @@ class BaseAgentProfile(BaseModel):
 
 
 class AgentProfile(BaseAgentProfile, JsonModel):
-    pass
+    def __init__(self, **kwargs: Any):
+        if "pk" not in kwargs:
+            kwargs["pk"] = ""
+        super().__init__(**kwargs)
 
 
 class BaseEnvironmentProfile(BaseModel):
-    pk: str = Field(default_factory=lambda: "")
+    pk: str | None = Field(default_factory=lambda: "")
     codename: str = Field(
         index=True,
         default_factory=lambda: "",
@@ -92,11 +96,14 @@ class BaseEnvironmentProfile(BaseModel):
 
 
 class EnvironmentProfile(BaseEnvironmentProfile, JsonModel):
-    pass
+    def __init__(self, **kwargs: Any):
+        if "pk" not in kwargs:
+            kwargs["pk"] = ""
+        super().__init__(**kwargs)
 
 
 class BaseRelationshipProfile(BaseModel):
-    pk: str = Field(default_factory=lambda: "")
+    pk: str | None = Field(default_factory=lambda: "")
     agent_1_id: str = Field(index=True)
     agent_2_id: str = Field(index=True)
     relationship: RelationshipType = Field(
@@ -112,14 +119,22 @@ class BaseRelationshipProfile(BaseModel):
 
 
 class RelationshipProfile(BaseRelationshipProfile, JsonModel):
-    pass
+    def __init__(self, **kwargs: Any):
+        if "pk" not in kwargs:
+            kwargs["pk"] = ""
+        super().__init__(**kwargs)
 
 
 class EnvironmentList(JsonModel):
-    pk: str = Field(default_factory=lambda: "")
+    pk: str | None = Field(default_factory=lambda: "")
     name: str = Field(index=True)
     environments: list[str] = Field(default_factory=lambda: [])
     agent_index: list[str] | None = Field(default_factory=lambda: None)
+
+    def __init__(self, **kwargs: Any):
+        if "pk" not in kwargs:
+            kwargs["pk"] = ""
+        super().__init__(**kwargs)
 
     # validate the length of agent_index should be same as environments
     @model_validator(mode="after")
@@ -130,7 +145,7 @@ class EnvironmentList(JsonModel):
         )
         if agent_index is None:
             return self
-        assert (
-            len(environments) == len(agent_index)
-        ), f"Number of environments {len(environments)} and agent_index {len(agent_index)} do not match"
+        assert len(environments) == len(agent_index), (
+            f"Number of environments {len(environments)} and agent_index {len(agent_index)} do not match"
+        )
         return self

--- a/sotopia/database/persistent_profile.py
+++ b/sotopia/database/persistent_profile.py
@@ -145,7 +145,7 @@ class EnvironmentList(JsonModel):
         )
         if agent_index is None:
             return self
-        assert len(environments) == len(agent_index), (
-            f"Number of environments {len(environments)} and agent_index {len(agent_index)} do not match"
-        )
+        assert (
+            len(environments) == len(agent_index)
+        ), f"Number of environments {len(environments)} and agent_index {len(agent_index)} do not match"
         return self


### PR DESCRIPTION
<!--
Thanks for creating this pull request 🤗
Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
# <!-- Issue # here -->

## 📑 Description
<!-- Add a brief description of the pr -->

Instantiating classes `AgentProfile` or `EnvironmentProfile` without specifying the `pk` field causes validation errors because of type conflict with Redis' `JsonModel.pk`:

```
/home/user/code/sotopia/.venv/lib/python3.11/site-packages/pydantic/_internal/_fields.py:192: UserWarning: Field name "pk" in "EnvironmentList" shadows an attribute in parent "JsonModel"
  warnings.warn(
Successfully connected to Redis database redis://localhost:6379
Successfully initialized Redis OM object.
Traceback (most recent call last):
  File "/home/user/code/sotopia/./examples/minimalist_demo.py", line 43, in <module>
    agent_profile_1 = AgentProfile(
                      ^^^^^^^^^^^^^
  File "/home/user/code/sotopia/.venv/lib/python3.11/site-packages/redis_om/model/model.py", line 1905, in __init__
    super().__init__(*args, **kwargs)
  File "/home/user/code/sotopia/.venv/lib/python3.11/site-packages/redis_om/model/model.py", line 1455, in __init__
    super().__init__(**data)
  File "/home/user/code/sotopia/.venv/lib/python3.11/site-packages/pydantic/main.py", line 214, in __init__
    validated_self = self.__pydantic_validator__.validate_python(data, self_instance=self)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
pydantic_core._pydantic_core.ValidationError: 1 validation error for AgentProfile
pk
  Input should be a valid string [type=string_type, input_value=<redis_om.model.model.Exp...bject at 0x7f026badcd50>, input_type=ExpressionProxy]
    For further information visit https://errors.pydantic.dev/2.10/v/string_type
```

This PR fixes the error by assigning an empty string to `pk` if it is not specified.

Related: commit 5a158d87

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [x] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed
- [x] Branch name follows `type/descript` (e.g. `feature/add-llm-agents`)
- [x] Ready for code review

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
